### PR TITLE
:sparkles: add support for only a few payment methods

### DIFF
--- a/src/Controller/Gateways/AbstractGateway.php
+++ b/src/Controller/Gateways/AbstractGateway.php
@@ -100,6 +100,7 @@ abstract class AbstractGateway extends WC_Payment_Gateway
         $this->postFormatter = $postFormatter ?? new PostFormatter;
         $this->model = $gateway ?? new Gateway;
         $this->checkout = $checkout ?? new Checkout;
+        $this->subscription = new Subscription;
         $this->wooOrderRepository = $wooOrderRepository ?? new WooOrderRepository;
         $this->template = $template ?? new Template;
         $this->id = 'woo-pagarme-payments-' . $this->method;
@@ -122,7 +123,7 @@ abstract class AbstractGateway extends WC_Payment_Gateway
         add_action('admin_enqueue_scripts', array($this, 'payments_scripts'));
 
         //Subscriptions
-        if ($this->hasSubscriptionSupport() && Subscription::hasSubscriptionPlugin()) {
+        if ($this->hasSubscriptionSupport() && $this->subscription->hasSubscriptionPlugin()) {
             $this->addSupportToSubscription();
         }
     }
@@ -153,10 +154,15 @@ abstract class AbstractGateway extends WC_Payment_Gateway
             'subscription_payment_method_change_admin',
             'multiple_subscriptions',
         );
-        add_action('woocommerce_scheduled_subscription_payment_' . $this->id, [$this, 'schedule_subscription_payment'], 10, 2);
+        add_action(
+            'woocommerce_scheduled_subscription_payment_'.$this->id,
+            [$this, 'schedule_subscription_payment'],
+            10,
+            2
+        );
     }
 
-    function schedule_subscription_payment($amount_to_charge, $order)
+    public function schedule_subscription_payment($amountToCharge, $order)
     {
         $this->subscription->process($order);
     }

--- a/src/Controller/Gateways/Billet.php
+++ b/src/Controller/Gateways/Billet.php
@@ -13,6 +13,7 @@ namespace Woocommerce\Pagarme\Controller\Gateways;
 
 use Woocommerce\Pagarme\Model\Payment\Billet\BankInterface;
 use Woocommerce\Pagarme\Model\Payment\Billet\Banks;
+use Woocommerce\Pagarme\Model\Subscription;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -29,6 +30,13 @@ class Billet extends AbstractGateway
     /** @var string */
     protected $method = \Woocommerce\Pagarme\Model\Payment\Billet::PAYMENT_CODE;
 
+    /**
+     * @return boolean
+     */
+    public function hasSubscriptionSupport(): bool
+    {
+        return true;
+    }
     /**
      * @return array
      */

--- a/src/Controller/Gateways/Billet.php
+++ b/src/Controller/Gateways/Billet.php
@@ -13,7 +13,6 @@ namespace Woocommerce\Pagarme\Controller\Gateways;
 
 use Woocommerce\Pagarme\Model\Payment\Billet\BankInterface;
 use Woocommerce\Pagarme\Model\Payment\Billet\Banks;
-use Woocommerce\Pagarme\Model\Subscription;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/src/Controller/Gateways/CreditCard.php
+++ b/src/Controller/Gateways/CreditCard.php
@@ -32,6 +32,13 @@ class CreditCard extends AbstractGateway
     protected $method = \Woocommerce\Pagarme\Model\Payment\CreditCard::PAYMENT_CODE;
 
     /**
+     * @return boolean
+     */
+    public function hasSubscriptionSupport(): bool
+    {
+        return true;
+    }
+    /**
      * @return array
      */
     public function append_form_fields()

--- a/src/Controller/Gateways/Pix.php
+++ b/src/Controller/Gateways/Pix.php
@@ -27,6 +27,13 @@ class Pix extends AbstractGateway
     protected $method = \Woocommerce\Pagarme\Model\Payment\Pix::PAYMENT_CODE;
 
     /**
+     * @return boolean
+     */
+    public function hasSubscriptionSupport(): bool
+    {
+        return true;
+    }
+    /**
      * @return array
      */
     public function append_form_fields()

--- a/src/Model/Subscription.php
+++ b/src/Model/Subscription.php
@@ -9,10 +9,6 @@
 
 namespace Woocommerce\Pagarme\Model;
 
-use Woocommerce\Pagarme\Controller\Gateways\AbstractGateway;
-use Woocommerce\Pagarme\Controller\Orders;
-use Woocommerce\Pagarme\Helper\Utils;
-use Woocommerce\Pagarme\Model\Config\Source\CheckoutTypes;
 
 if (!defined('ABSPATH')) {
     exit(0);
@@ -20,12 +16,9 @@ if (!defined('ABSPATH')) {
 
 use WC_Order;
 use WC_Subscriptions_Cart;
-use Woocommerce\Pagarme\Model\Payment\Data\AbstractPayment;
-use Woocommerce\Pagarme\Model\Payment\Data\Card;
-use Woocommerce\Pagarme\Model\Payment\Data\Cards;
-use Woocommerce\Pagarme\Model\Payment\Data\Multicustomers;
-use Woocommerce\Pagarme\Model\Payment\Data\PaymentRequest;
-use Woocommerce\Pagarme\Model\Payment\Data\PaymentRequestInterface;
+use Woocommerce\Pagarme\Controller\Orders;
+use Woocommerce\Pagarme\Model\Config\Source\CheckoutTypes;
+
 
 class Subscription
 {
@@ -164,9 +157,8 @@ class Subscription
         return false;
     }
 
-    public function hasSubscriptionPlugin(): bool
+    public static function hasSubscriptionPlugin(): bool
     {
 		return class_exists('WC_Subscriptions');
 	}
-
 }

--- a/src/Model/Subscription.php
+++ b/src/Model/Subscription.php
@@ -157,7 +157,7 @@ class Subscription
         return false;
     }
 
-    public static function hasSubscriptionPlugin(): bool
+    public function hasSubscriptionPlugin(): bool
     {
 		return class_exists('WC_Subscriptions');
 	}


### PR DESCRIPTION
Adds Woocommerce Subscriptions support for the following payment methods:
- Credit Card
- Billet
- Pix