### PR TITLE
fix: disable cart_checkout_blocks compatibility

### DIFF
--- a/src/Model/FeatureCompatibilization.php
+++ b/src/Model/FeatureCompatibilization.php
@@ -19,7 +19,7 @@ class FeatureCompatibilization
             'analytics'             => false,
             'new_navigation'        => false,
             'product_block_editor'  => true,
-            'cart_checkout_blocks'  => true,
+            'cart_checkout_blocks'  => false,
             'woocommerce_custom_orders_table_enabled'           => true,
             'woocommerce_custom_orders_table_data_sync_enabled' => true,
         ];


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

> [!IMPORTANT]
> Certifique-se de criar o PR para a branch **develop**.

### Qual o tipo de PR é esse? (marque todos os aplicáveis)
- [ ] Refatoração
- [ ] Adição de funcionalidade
- [x] Correção de bug
- [ ] Otimização
- [ ] Atualização de documentação

### Descrição
Desabilitado a compatibilização com a funcionalidade cart_checkout_blocks do woocommerce.


### Cenários testados
N/A