### PR TITLE
fix: missing billing_first_name and billing_last_name required fields…

### DIFF
--- a/woo-pagarme-payments.php
+++ b/woo-pagarme-payments.php
@@ -215,6 +215,8 @@ function wcmpAdminNoticeCheckoutFields()
     $requiredFields = [
         'billing_cpf',
         'billing_cnpj',
+        'billing_first_name',
+        'billing_last_name',
     ];
     if (!(new Config())->getAllowNoAddress()) {
         $requiredFields[] = 'billing_address_1';


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

> [!IMPORTANT]
> Certifique-se de criar o PR para a branch **develop**.

### Qual o tipo de PR é esse? (marque todos os aplicáveis)
- [ ] Refatoração
- [ ] Adição de funcionalidade
- [x] Correção de bug
- [ ] Otimização
- [ ] Atualização de documentação

### Descrição
Adição dos campos billing_first_name e billing_last_name na validação dos campos obrigatórios.


### Cenários testados
Desabilitado os campos billing_first_name e billing_last_name do checkout a mensagem de erro foi apresentado no admin.

![image](https://github.com/pagarme/woocommerce/assets/38541352/a633ad36-87bf-4d32-8fe5-143d880c966b)
![image](https://github.com/pagarme/woocommerce/assets/38541352/aff969cd-758d-44b3-b6a0-56662e727369)

