### PR TITLE
fix: removed hiperlink from pix code in emails

### DIFF
--- a/templates/order/email/pix.phtml
+++ b/templates/order/email/pix.phtml
@@ -22,7 +22,11 @@ if (!function_exists('add_action')) {
     </tr>
     <tr>
         <th class="td" scope="row"><?= __('Copyable Code', 'woo-pagarme-payments'); ?>:</th>
-        <td class="td"><?= $this->getRawQrCode() ?></td>
+        <td class="td">
+            <a href="" style="text-decoration: none; color: #636363; cursor: default">
+                <?= $this->getRawQrCode() ?>
+            </a>
+        </td>
     </tr>
     <tr>
         <th class="td" scope="row"><?= __('Instructions', 'woo-pagarme-payments'); ?>:</th>


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

> [!IMPORTANT]
> Certifique-se de criar o PR para a branch **develop**.

### Qual o tipo de PR é esse? (marque todos os aplicáveis)
- [ ] Refatoração
- [ ] Adição de funcionalidade
- [ ] Correção de bug
- [x] Otimização
- [ ] Atualização de documentação

### Descrição
Adicionado hiperlink com o atributo `href` vazio para que gerenciadores de e-mail não gere a tag automaticamente.


### Cenários testados
Verificado e-mail recebido de uma compra via Pix.
