### PR TITLE
Fix subscription config fields

### DIFF
--- a/src/Controller/Gateways/Billet.php
+++ b/src/Controller/Gateways/Billet.php
@@ -59,11 +59,14 @@ class Billet extends AbstractGateway
      */
     public function append_form_fields()
     {
-        return [
+        $fields = [
             'billet_deadline_days' => $this->field_billet_deadline_days(),
             'billet_instructions' => $this->field_billet_instructions(),
-            'billet_allowed_in_subscription' => $this->field_billet_allowed_for_subscription(),
         ];
+        if (Subscription::hasSubscriptionPlugin()) {
+            $fields['billet_allowed_in_subscription'] = $this->field_billet_allowed_for_subscription();
+        }
+        return $fields;
     }
 
     /**

--- a/src/Controller/Gateways/Pix.php
+++ b/src/Controller/Gateways/Pix.php
@@ -55,11 +55,14 @@ class Pix extends AbstractGateway
      */
     public function append_form_fields()
     {
-        return [
+        $fields = [
             'pix_qrcode_expiration_time' => $this->field_pix_qrcode_expiration_time(),
             'pix_additional_data' => $this->field_pix_additional_data(),
-            'pix_allowed_in_subscription' => $this->field_pix_allowed_for_subscription(),
         ];
+        if (Subscription::hasSubscriptionPlugin()) {
+            $fields['pix_allowed_in_subscription'] = $this->field_pix_allowed_for_subscription();
+        }
+        return $fields;
     }
 
     public function field_pix_qrcode_expiration_time()


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

> [!IMPORTANT]
> Certifique-se de criar o PR para a branch **develop**.

### Qual o tipo de PR é esse? (marque todos os aplicáveis)
- [ ] Refatoração
- [ ] Adição de funcionalidade
- [x] Correção de bug
- [ ] Otimização
- [ ] Atualização de documentação

### Descrição
Campos das configurações de subscription para pix e boleto foram removidos quando o plugin **Woo Subscriptions** está desativado ou não instalado.


### Cenários testados
Constatei que os campos não aparecem quando o plugin é desabilitado.
