### PR TITLE
Fix: PAA-1277 fix PR steps to fail when has sintax error

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     container:
-      image: php:7.2-apache
+      image: php:7.1-apache
     steps:
       -
         name: Checkout

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,7 +39,11 @@ jobs:
           php composer.phar --version
       -
         name: Check PHP sintax
-        run: find . -name \*.php -exec php -l "{}" \;
+        run: |
+          find . -name \*.php -exec php -l "{}" \; | tee errors.log
+          if grep -q "Sintax errors:" errors.log; then
+            exit 1
+          fi
       -
         name: Install project dependences
         run:


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

> [!IMPORTANT]
> Certifique-se de criar o PR para a branch **develop**.

### Qual o tipo de PR é esse? (marque todos os aplicáveis)
- [ ] Refatoração
- [ ] Adição de funcionalidade
- [x] Correção de bug
- [ ] Otimização
- [ ] Atualização de documentação

### Descrição
Essa alteração faz com que erros de sintax não passem nas validações. 
Também diminui a versão do php de execução para 7.1. 


### Cenários testados
Não necessário.
