### PR TITLE
fix: use the appropriate getters (woocommerce CRUD)

### DIFF
--- a/src/Concrete/WoocommercePlatformOrderDecorator.php
+++ b/src/Concrete/WoocommercePlatformOrderDecorator.php
@@ -476,12 +476,12 @@ class WoocommercePlatformOrderDecorator extends AbstractPlatformOrderDecorator
             $customer = $savedCustomer;
         }
 
-        $fullName = "{$order->billing_first_name} {$order->billing_last_name}";
+        $fullName = "{$this->getPlatformOrder()->get_billing_first_name()} {$this->getPlatformOrder()->get_billing_last_name()}";
         $fullName = substr($fullName, 0, 64);
         $fullName = preg_replace("/  /", " ", $fullName);
 
         $customer->setName($fullName);
-        $customer->setEmail(substr($order->billing_email, 0, 64));
+        $customer->setEmail(substr($this->getPlatformOrder()->get_billing_email(), 0, 64));
 
         $cleanDocument = preg_replace(
             '/\D/',
@@ -521,11 +521,11 @@ class WoocommercePlatformOrderDecorator extends AbstractPlatformOrderDecorator
         $homeNumber   = $phones["home_phone"]["complete_phone"];
         $mobileNumber = $phones["mobile_phone"]["complete_phone"];
 
-        $fullName = "{$order->billing_first_name} {$order->billing_last_name}";
+        $fullName = "{$this->getPlatformOrder()->get_billing_first_name()} {$this->getPlatformOrder()->get_billing_last_name()}";
         $fullName = substr($fullName, 0, 64);
         $fullName = preg_replace("/  /", " ", $fullName);
 
-        $email = substr($order->billing_email, 0, 64);
+        $email = substr($this->getPlatformOrder()->get_billing_email(), 0, 64);
 
         $customer = new Customer();
 

--- a/src/Helper/Utils.php
+++ b/src/Helper/Utils.php
@@ -476,8 +476,8 @@ class Utils
             'complement'   => substr($order->getWcOrder()->get_billing_address_2(), 0, 64),
             'zip_code'     => preg_replace('/[^\d]+/', '', $order->getWcOrder()->get_billing_postcode()),
             'neighborhood' => substr($order->get_meta('billing_neighborhood'), 0, 64),
-            'city'         => substr($order->get_meta('billing_city'), 0, 64),
-            'state'        => substr($order->get_meta('billing_state'), 0, 2),
+            'city'         => substr($order->getWcOrder()->get_billing_city(), 0, 64),
+            'state'        => substr($order->getWcOrder()->get_billing_state(), 0, 2),
             'country'      => 'BR'
         );
     }
@@ -533,7 +533,7 @@ class Utils
     {
 
         $phones = array();
-        $phone = $order->get_meta('billing_phone');
+        $phone = $order->getWcOrder()->get_billing_phone();
         $cellphone = $order->get_meta('billing_cellphone');
 
         if ($phone) {

--- a/src/Model/Order.php
+++ b/src/Model/Order.php
@@ -201,6 +201,22 @@ class Order extends Meta
 
     private function handle_shipping_properties($prop)
     {
+        $method_get_shipping = 'get_shipping_' . $prop;
+        if (method_exists($this->wc_order, $method_get_shipping)) {
+            $shipping_prop = $this->wc_order->{$method_get_shipping}();
+            if ( ! empty( $shipping_prop ) ) {
+                return $shipping_prop;
+            }
+        }
+
+        $method_get_billing = 'get_billing_' . $prop;
+        if (method_exists($this->wc_order, $method_get_billing)) {
+            $shipping_prop = $this->wc_order->{$method_get_billing}();
+            if ( ! empty( $shipping_prop ) ) {
+                return $shipping_prop;
+            }
+        }
+
         $shipping_prop = $this->__get("shipping_{$prop}");
 
         if (empty($shipping_prop)) {

--- a/src/Model/Payment/Data/Googlepay.php
+++ b/src/Model/Payment/Data/Googlepay.php
@@ -42,7 +42,9 @@ class Googlepay extends AbstractPayment
     }
 
     protected function init() {
-        $this->{$this->getMethod('token')}($this->getPostPaymentContent()['googlepay']['payload']);
+        if ($this->getPostPaymentContent() && is_array($this->getPostPaymentContent()) && array_key_exists('googlepay', $this->getPostPaymentContent())) {
+            $this->{$this->getMethod('token')}($this->getPostPaymentContent()['googlepay']['payload']);
+        }
     }
 
     protected function setToken($data)


### PR DESCRIPTION
### Qual o tipo de PR é esse? (marque todos os aplicáveis)
- [ ] Refatoração
- [ ] Adição de funcionalidade
- [x] Correção de bug
- [ ] Otimização
- [ ] Atualização de documentação

### Descrição
Este PR corrige warnings que estavam sendo gerados. A maioria deles por não utilizar os getters CRUD do woocommerce.
Issue relacionada: #480 

Atualização:: Agora vi que há outro PR recente (#523) que corrige uma parte dos problemas que meu PR corrige.

### Cenários testados
Compra no cartão de crédito, em loja com HPOS ativado