### PR TITLE
fix: wrong website url when using a custom directory for WP install

### DIFF
--- a/src/Helper/Utils.php
+++ b/src/Helper/Utils.php
@@ -188,7 +188,7 @@ class Utils
      */
     public static function get_site_url($path = '')
     {
-        return esc_url(get_site_url(null, $path));
+        return esc_url(get_home_url(null, $path));
     }
 
     /**


### PR DESCRIPTION
### Qual o tipo de PR é esse? (marque todos os aplicáveis)
- [ ] Refatoração
- [ ] Adição de funcionalidade
- [x] Correção de bug
- [ ] Otimização
- [ ] Atualização de documentação

### Descrição
Este PR corrige a URL usada na configuração inicial do plugin quando se usa um diretório de instalação diferente da URL do site. 
Por exemplo: numa instalação do [Bedrock](https://roots.io/bedrock/), a URL do wordpress é `https://www.dominio.com.br/wp` e a URL do site é `https://www.dominio.com.br`.  Ao fazer a configuração inicial do plugin do pagar.me, o correto seria que os webhooks e a URL de retorno sejam configurados para `/wc-api/pagarme-hub`, e não `/wp/wc-api/pagarme-hub`, que é como está hoje.


### Cenários testados
Instalação de WordPress usando o [Bedrock](https://roots.io/bedrock/). 
Não tenho certeza se este PR gera algum problema em outros tipos de instalação

