### PR TITLE
bugfix: reapply card fields mask on updated_checkout event

### DIFF
--- a/assets/javascripts/front/checkout/model/payment/card.js
+++ b/assets/javascripts/front/checkout/model/payment/card.js
@@ -11,6 +11,7 @@ let pagarmeCard = {
     valueTarget: 'input[data-pagarme-element="order-value"]',
     installmentsTarget: '[data-pagarme-component="installments"]',
     installmentsInfoTarget: '[data-pagarme-component="installments-info"]',
+    maskTargets: 'input[class*="pagarme-card-form"][data-mask]',
     mundiCdn: 'https://cdn.mundipagg.com/assets/images/logos/brands/png/',
     tokenElement: '[data-pagarme-element="token"]',
     fieldsetCardElements: 'fieldset[data-pagarmecheckout="card"]',
@@ -475,6 +476,7 @@ let pagarmeCard = {
     addEventListener: function () {
         jQuery(document.body).on('updated_checkout', function () {
             pagarmeCard.renewEventListener();
+            jQuery.applyDataMask(pagarmeCard.maskTargets);
             let creditCardField = jQuery(pagarmeCard.cardNumberTarget);
             creditCardField.each(function () {
                 if (jQuery(this)?.val() && pagarmeCard.isVisible(jQuery(this)[0])) {


### PR DESCRIPTION
![The Mask](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExMGNkejIzeGpsZXFpcWNlZjhzcjI3eG02d3htdjJlb3dxOGgybGVmNSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/MPn6T23RG76qk/giphy.gif)

> [!IMPORTANT]
> Certifique-se de criar o PR para a branch **develop**.

### Qual o tipo de PR é esse? (marque todos os aplicáveis)
- [ ] Refatoração
- [ ] Adição de funcionalidade
- [x] Correção de bug
- [ ] Otimização
- [ ] Atualização de documentação

### Descrição
No **checkout antigo**, quando algum plugin externo realizava update do checkout, as máscaras dos campos de cartão de crédito eram removidas e não eram aplicadas novamente.

Para corrigir, apliquei a função `applyDataMask()` no evento `updated_checkout` do WooCommerce.


### Cenários testados
Teste efetuado diretamente no site do cliente, no método de **Cartão de Crédito** e **Dois Cartões**.