### PR TITLE
Bugfix/subdirectory webhook url/plats 83

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -226,10 +226,9 @@ class Core
     {
         $url = !$custom_url ? Utils::get_site_url() : $custom_url;
 
-		// Foi alterado no passado para corrigir URLs com subdiretórios.
-	    // Recentemente tivemos quatro cases de clientes que tiveram
-	    // problemas com a URL do webhook em domínios com
-	    // subdiretórios, por isso removemos o código abaixo.
+		// Condição foi incluída no passado visando corrigir URLs com subdiretórios.
+	    // Recentemente tivemos quatro cases de clientes que tiveram problemas com
+	    // a URL do webhook em domínios com subdiretórios, por isso removemos o código abaixo.
 
 //        if ( !$custom_url ) {
 //            $parsedUrl = parse_url($url);

--- a/src/Core.php
+++ b/src/Core.php
@@ -225,10 +225,16 @@ class Core
     public static function get_webhook_url($custom_url = false)
     {
         $url = !$custom_url ? Utils::get_site_url() : $custom_url;
-        if ( !$custom_url ) {
-            $parsedUrl = parse_url($url);
-            $url = $parsedUrl['scheme'] . '://' . $parsedUrl['host'];
-        }
+
+		// Foi alterado no passado para corrigir URLs com subdiretórios.
+	    // Recentemente tivemos quatro cases de clientes que tiveram
+	    // problemas com a URL do webhook em domínios com
+	    // subdiretórios, por isso removemos o código abaixo.
+
+//        if ( !$custom_url ) {
+//            $parsedUrl = parse_url($url);
+//            $url = $parsedUrl['scheme'] . '://' . $parsedUrl['host'];
+//        }
 
         return sprintf('%s/wc-api/%s/', $url, self::get_webhook_name());
     }


### PR DESCRIPTION
![Chandler File Cabinet](https://media1.tenor.com/m/RJsDaYG8EgcAAAAd/friends-chandler.gif)

> [!IMPORTANT]
> Certifique-se de criar o PR para a branch **develop**.

### Qual o tipo de PR é esse? (marque todos os aplicáveis)
- [ ] Refatoração
- [ ] Adição de funcionalidade
- [x] Correção de bug
- [ ] Otimização
- [ ] Atualização de documentação

### Descrição
Ao efetuar a integração com o hub, lojas que a URL se encontravam em subdiretório estavam falhando na entrega dos Webhooks, pois o endereço de destino não incluía o subdiretório.

Código foi comentado, e não excluído, com orientação do TM

### Cenários testados
Integração testada diretamente em site de clientes
