### PR TITLE
fix: save metadata with default method

### DIFF
--- a/src/Model/Checkout.php
+++ b/src/Model/Checkout.php
@@ -266,7 +266,7 @@ class Checkout
         if (!array_key_exists('authentication', $fields)) {
             return;
         }
-        $order->pagarme_tds_authentication = json_encode($fields["authentication"]);
+        $order->update_meta('pagarme_tds_authentication', json_encode($fields['authentication']));
     }
 
     private function extractMulticustomers(array &$fields, PaymentRequestInterface $paymentRequest)


### PR DESCRIPTION
![Git Merge](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExM3NnMzE4OHc3ZHU4cWdneXJ5cng1dzc3dWtkY3VtOWZzcnNvMm9uayZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/MT5UUV1d4CXE2A37Dg/giphy.gif)

> [!IMPORTANT]
> Certifique-se de criar o PR para a branch **develop**.

### Qual o tipo de PR é esse? (marque todos os aplicáveis)
- [ ] Refatoração
- [ ] Adição de funcionalidade
- [x] Correção de bug
- [ ] Otimização
- [ ] Atualização de documentação

### Descrição
Esse PR faz com que o nosso checkout utilize a maneira padrão do Woocommerce para salvar dados no Metadata. Outros pontos já utilizam isso, apenas o nó de TDS estava fora.


### Cenários testados
Compras com e sem 3DS e compras com e sem HPOS ativo.
