### PR TITLE
get card brand on place order button

### DIFF
--- a/assets/javascripts/front/checkout/model/payment/card.js
+++ b/assets/javascripts/front/checkout/model/payment/card.js
@@ -488,6 +488,14 @@ let pagarmeCard = {
         jQuery(this.voucherDocumentHolder).empty();
         jQuery(this.voucherDocumentHolder).val(cpf);
     },
+    fillCardBrandIfEmpty: function () {
+        if (pagarmeCard.isPagarmeCard()) {
+            const brandInputVal = pagarmeCard.getSelectedPaymentMethod().parent().find(pagarmeCard.brandTarget).val();
+            if (brandInputVal === '') {
+                jQuery(pagarmeCard.cardNumberTarget).trigger('change');
+            }
+        }
+    },
     addEventListener: function () {
         jQuery(document.body).on('updated_checkout', function () {
             pagarmeCard.renewEventListener();
@@ -501,18 +509,12 @@ let pagarmeCard = {
         });
 
         jQuery(document).ready(function () {
-            jQuery('form.checkout')
-                .on('checkout_place_order', function (event) {
-                    return pagarmeCard.canExecute(event);
-                })
-                .on( 'click', '#place_order', function(event){
-                    if (pagarmeCard.isPagarmeCard()) {
-                        event.preventDefault();
-                        jQuery(pagarmeCard.cardNumberTarget).trigger('change');
-                        jQuery('form.checkout').submit();
-                    }
-                });
+            jQuery('form.checkout').on('checkout_place_order', function (event) {
+                pagarmeCard.fillCardBrandIfEmpty();
+                return pagarmeCard.canExecute(event);
+            });
             jQuery('form#order_review').on('submit', function (event) {
+                pagarmeCard.fillCardBrandIfEmpty();
                 return pagarmeCard.canExecute(event);
             });
         });


### PR DESCRIPTION
![Sold](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExOG9iczBkcDE2angwc2d1dmFsMzk5ZTIyMThuOWp5dWtjNWFxaTh6bSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3o6Mb8uXg4gS3diqpG/giphy.gif)

> [!IMPORTANT]
> Certifique-se de criar o PR para a branch **develop**.

### Qual o tipo de PR é esse? (marque todos os aplicáveis)
- [ ] Refatoração
- [ ] Adição de funcionalidade
- [x] Correção de bug
- [ ] Otimização
- [ ] Atualização de documentação

### Descrição
Modificando a chamada da API da bandeira de cartão no click do botão "Finalizar Pedido" para corrigir uma incompatibilidade encontrada quando o 3DS está ativo.


### Cenários testados
Cartão de crédito (com e sem 3DS) e voucher.